### PR TITLE
Removido config o pom.xml, para que a aplicação rodasse corretamente …

### DIFF
--- a/api-gerenciador-de-tarefas/pom.xml
+++ b/api-gerenciador-de-tarefas/pom.xml
@@ -80,12 +80,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<mainClass>com.leonardo.api_gerenciador_de_tarefas</mainClass>
-					<jvmArguments>
-						-Dserver.port=80
-					</jvmArguments>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
…na porta 80 no servidor, pois além de eu ter configurado o nome da mainClass errado, esse comando pode ser passado diretamente lá no Azure.